### PR TITLE
fix: initiative order enemy wins ties and heal accidentally damaging

### DIFF
--- a/backlog.md
+++ b/backlog.md
@@ -1,4 +1,6 @@
 # Backlog
+- [ ] FIX: condition that ends at Bob's end of turn, if added during bob's turn
+      will end at that turn, not the next (as expected)
 - [x] persistent damage tracking (what about weakness and resistence)
 - [x] remove dex, doesn't rule ties
 - [ ] enemies go first in ties

--- a/backlog.md
+++ b/backlog.md
@@ -3,7 +3,8 @@
       will end at that turn, not the next (as expected)
 - [x] persistent damage tracking (what about weakness and resistence)
 - [x] remove dex, doesn't rule ties
-- [ ] enemies go first in ties
+- [x] enemies go first in ties
+- [ ] undo/redo
 - [ ] allow ties to be reordered per GM discression (fx command `order <names>`)
 - [ ] allow delaying characters (choosing later init slot)
 - [ ] edit info

--- a/src/character.rs
+++ b/src/character.rs
@@ -1,4 +1,4 @@
-use std::{cmp::Ordering, ops::RemAssign};
+use std::cmp::Ordering;
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -20,7 +20,7 @@ impl Health {
     }
 
     fn damage(&mut self, x: u32) {
-        self.current = self.max.saturating_sub(x);
+        self.current = self.current.saturating_sub(x);
     } 
 }
 

--- a/src/character.rs
+++ b/src/character.rs
@@ -1,4 +1,4 @@
-use std::cmp::Ordering;
+use std::{cmp::Ordering, ops::RemAssign};
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -16,11 +16,11 @@ impl Health {
     }
 
     fn heal(&mut self, x: u32) {
-        self.current = self.max.min(self.current - x);
+        self.current = self.max.min(self.current + x);
     }
 
     fn damage(&mut self, x: u32) {
-        self.current = self.max.min(self.current - x);
+        self.current = self.max.saturating_sub(x);
     } 
 }
 
@@ -42,8 +42,11 @@ impl PartialOrd for Chr {
 impl Ord for Chr {
     fn cmp(&self, other: &Self) -> Ordering {
         if self.init != other.init { return other.init.cmp(&self.init) }
-
-        Ordering::Equal
+        match (self.player, other.player) {
+            (true, false) => Ordering::Greater,
+            (false, true) => Ordering::Less,
+            _ => Ordering::Equal
+        }
     }
 }
 
@@ -122,5 +125,21 @@ mod tests {
         let c2 = Chr::builder("b", 20, true).build();
 
         assert_eq!(Ordering::Greater, c1.cmp(&c2));
+    }
+
+    #[test]
+    fn chr_order_same_init_enemy_less_than_player() {
+        let c1 = Chr::builder("a", 10, false).build();
+        let c2 = Chr::builder("b", 10, true).build();
+
+        assert_eq!(Ordering::Less, c1.cmp(&c2));
+    }
+
+    #[test]
+    fn chr_order_same_init_enemy_equal_enemy() {
+        let c1 = Chr::builder("a", 10, false).build();
+        let c2 = Chr::builder("b", 10, false).build();
+
+        assert_eq!(Ordering::Equal, c1.cmp(&c2));
     }
 }

--- a/src/conditions/condition_manager.rs
+++ b/src/conditions/condition_manager.rs
@@ -101,12 +101,18 @@ impl ConditionManager {
                     (_, Condition::Valued { term: ValuedTerm::Until(e), .. } |
                         Condition::NonValued { term: NonValuedTerm::Until(e), .. }) if &e == event => None,
                     (affected, Condition::Valued { term: ValuedTerm::Reduced(e, reduction), level, cond }) if &e == event => {
-                        let new_cond = Condition::Valued { 
-                            cond, 
-                            term: ValuedTerm::Reduced(e, reduction), 
-                            level: level.saturating_sub(reduction) 
-                        };
-                        Some((affected, new_cond))
+                        let new_level = level.saturating_sub(reduction);
+                        match new_level {
+                            0 => None,
+                            level => {
+                                let new_cond = Condition::Valued { 
+                                    cond, 
+                                    term: ValuedTerm::Reduced(e, reduction), 
+                                    level 
+                                };
+                                Some((affected, new_cond))
+                            }
+                        }
                     },
                     (affected, cond) => Some((affected, cond))
                 }

--- a/src/tracker.rs
+++ b/src/tracker.rs
@@ -170,6 +170,7 @@ impl<S: Saver> Tracker<S> {
             if let Some(damage) = damage {
                 // It can only fail if there is no character by the name,
                 // which there naturally will always be in this if body
+                println!("P. DAMAGE {damage} on {chr:?}");
                 self.damage(&chr.name, damage.into())?;
             }
         }

--- a/tests/conditions_tests.rs
+++ b/tests/conditions_tests.rs
@@ -194,3 +194,30 @@ fn persistent_damage_reduces_health_at_end_of_turn() -> tracker::Result<()> {
 
     Ok(())
 }
+
+#[test]
+fn persistent_bleed_10_reduced_start_alice_on_bob() -> tracker::Result<()> {
+    let mut t: Tracker<NoSaver> = Tracker::default();
+    let alice = Chr::builder("Alice", 10, false).build();
+    let bob = Chr::builder("Bob", 13, false).with_health(Health::new(40)).build();
+    t.add_chr(alice)?;
+    t.add_chr(bob)?;
+    let bleed = Condition::builder()
+        .condition(ValuedCondition::PersistentDamage(DamageType::Bleed))
+        .value(10)
+        .term(ValuedTerm::Reduced(TurnEvent::StartOfTurn(String::from("Alice")), 3))
+        .build();
+    t.add_condition("Bob", bleed)?;
+
+    t.end_turn()?;
+    t.end_turn()?;
+
+    assert_eq!(30, t.get_chr("Bob").unwrap().health.as_ref().unwrap().current);
+
+    t.end_turn()?;
+    t.end_turn()?;
+
+    assert_eq!(23, t.get_chr("Bob").unwrap().health.as_ref().unwrap().current);
+
+    Ok(())
+}

--- a/tests/tracker_change_test.rs
+++ b/tests/tracker_change_test.rs
@@ -33,13 +33,13 @@ fn rename_preserves_order() -> tracker::Result<()> {
     let mut t: Tracker<NoSaver> = Tracker::builder().with_chrs(vec![
         Chr::builder("Lucifer", 24, true).build(),
         Chr::builder("Link", 24, true).build(),
-        Chr::builder("Lament", 24, false).build(),
+        Chr::builder("Lament", 24, true).build(),
     ]).build();
 
     t.rename("Link", "Ganon")?;
     assert_eq!(Ok(Some(&Chr::builder("Lucifer", 24, true).build())), t.end_turn());
     assert_eq!(Ok(Some(&Chr::builder("Ganon", 24, true).build())), t.end_turn());
-    assert_eq!(Ok(Some(&Chr::builder("Lament", 24, false).build())), t.end_turn());
+    assert_eq!(Ok(Some(&Chr::builder("Lament", 24, true).build())), t.end_turn());
 
     Ok(())
 }


### PR DESCRIPTION
This PR mainly does two things
- Makes enemies win ties
- Fixes `heal` which accidentally damaged (silly mistake)

It also adds a test.