### PR TITLE
fix: `until end of turn` no longer triggers early

### DIFF
--- a/src/conditions.rs
+++ b/src/conditions.rs
@@ -67,15 +67,15 @@ impl Display for Condition {
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
 #[derive(Serialize, Deserialize, Hash)]
 pub enum TurnEvent {
-    StartOfTurn(String),
-    EndOfTurn(String)
+    StartOfNextTurn(String),
+    EndOfNextTurn(String)
 }
 
 impl Display for TurnEvent {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            Self::StartOfTurn(name) => write!(f, "start of {name} turn"),
-            Self::EndOfTurn(name) => write!(f, "end of {name} turn"),
+            Self::StartOfNextTurn(name) => write!(f, "start of next turn of {name}"),
+            Self::EndOfNextTurn(name) => write!(f, "end of next turn of {name}"),
         }
     }
 }

--- a/src/gui/terminalgui/parser/condition_parser.rs
+++ b/src/gui/terminalgui/parser/condition_parser.rs
@@ -167,15 +167,15 @@ fn parse_value(n: &str) -> Result<u8> {
 
 fn parse_turn_event(character: String, term_action: &[&str]) -> Result<TurnEvent> {
     match term_action {
-        ["start", "of", "turn"] => Ok(TurnEvent::StartOfTurn(character)),
-        ["end", "of", "turn"] => Ok(TurnEvent::EndOfTurn(character)),
+        ["start", "of", "turn"] => Ok(TurnEvent::StartOfNextTurn(character)),
+        ["end", "of", "turn"] => Ok(TurnEvent::EndOfNextTurn(character)),
         ["start", "of", character @ .., "turn"] => {
             let character = unparse(character);
-            Ok(TurnEvent::StartOfTurn(character))
+            Ok(TurnEvent::StartOfNextTurn(character))
         },
         ["end", "of", character @ .., "turn"] => {
             let character = unparse(character);
-            Ok(TurnEvent::EndOfTurn(character))
+            Ok(TurnEvent::EndOfNextTurn(character))
         },
         s => Err(Error::InvalidSyntax { 
             ty: "turn event", 
@@ -265,7 +265,7 @@ mod tests {
             character: String::from("Alice"),
             cond: Condition::builder()
                 .condition(NonValuedCondition::Dazzled)
-                .term(NonValuedTerm::Until(TurnEvent::EndOfTurn(String::from("Bob"))))
+                .term(NonValuedTerm::Until(TurnEvent::EndOfNextTurn(String::from("Bob"))))
                 .build()
         };
 
@@ -283,7 +283,7 @@ mod tests {
             cond: Condition::builder()
                 .condition(ValuedCondition::Frightened)
                 .value(2)
-                .term(ValuedTerm::Reduced(TurnEvent::EndOfTurn(String::from("Alice")), 1))
+                .term(ValuedTerm::Reduced(TurnEvent::EndOfNextTurn(String::from("Alice")), 1))
                 .build()
         };
 

--- a/src/gui/windowgui/condwindow.rs
+++ b/src/gui/windowgui/condwindow.rs
@@ -62,16 +62,16 @@ struct Data {
 
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
 enum TurnEventEntry {
-    StartOfTurn,
+    StartOfNextTurn,
     #[default]
-    EndOfTurn,
+    EndOfNextTurn,
 }
 
 impl From<TurnEvent> for TurnEventEntry {
     fn from(value: TurnEvent) -> Self {
         match value {
-            TurnEvent::StartOfTurn(_) => TurnEventEntry::StartOfTurn,
-            TurnEvent::EndOfTurn(_) => TurnEventEntry::EndOfTurn,
+            TurnEvent::StartOfNextTurn(_) => TurnEventEntry::StartOfNextTurn,
+            TurnEvent::EndOfNextTurn(_) => TurnEventEntry::EndOfNextTurn,
         }
     }
 }
@@ -79,8 +79,8 @@ impl From<TurnEvent> for TurnEventEntry {
 impl Display for TurnEventEntry {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            TurnEventEntry::StartOfTurn => write!(f, "start of turn"),
-            TurnEventEntry::EndOfTurn => write!(f, "end of turn"),
+            TurnEventEntry::StartOfNextTurn => write!(f, "start of next turn"),
+            TurnEventEntry::EndOfNextTurn => write!(f, "end of next turn"),
         }
     }
 }
@@ -212,8 +212,8 @@ fn show_add_button(ui: &mut Ui, data: &Data, character: &Chr) -> Option<Response
 
 fn create_turn_event(data: &Data) -> TurnEvent {
     let turn_event = match data.selected_turn_event {
-        TurnEventEntry::StartOfTurn => TurnEvent::StartOfTurn(data.selected_turn_event_character.clone()),
-        TurnEventEntry::EndOfTurn => TurnEvent::EndOfTurn(data.selected_turn_event_character.clone()),
+        TurnEventEntry::StartOfNextTurn => TurnEvent::StartOfNextTurn(data.selected_turn_event_character.clone()),
+        TurnEventEntry::EndOfNextTurn => TurnEvent::EndOfNextTurn(data.selected_turn_event_character.clone()),
     };
     turn_event
 }
@@ -335,14 +335,14 @@ fn show_reduced_options(ui: &mut Ui, data: &mut Data, characters: Vec<Chr>) {
                 .show_ui(ui, |ui| {
                     ui.selectable_value(
                         &mut data.selected_turn_event,
-                        TurnEventEntry::EndOfTurn,
-                        TurnEventEntry::EndOfTurn.to_string(),
+                        TurnEventEntry::EndOfNextTurn,
+                        TurnEventEntry::EndOfNextTurn.to_string(),
                     );
 
                     ui.selectable_value(
                         &mut data.selected_turn_event,
-                        TurnEventEntry::StartOfTurn,
-                        TurnEventEntry::StartOfTurn.to_string(),
+                        TurnEventEntry::StartOfNextTurn,
+                        TurnEventEntry::StartOfNextTurn.to_string(),
                     );
                 });
         });
@@ -376,14 +376,14 @@ fn show_until_options(ui: &mut Ui, data: &mut Data, characters: Vec<Chr>) {
                 .show_ui(ui, |ui| {
                     ui.selectable_value(
                         &mut data.selected_turn_event,
-                        TurnEventEntry::EndOfTurn,
-                        TurnEventEntry::EndOfTurn.to_string(),
+                        TurnEventEntry::EndOfNextTurn,
+                        TurnEventEntry::EndOfNextTurn.to_string(),
                     );
 
                     ui.selectable_value(
                         &mut data.selected_turn_event,
-                        TurnEventEntry::StartOfTurn,
-                        TurnEventEntry::StartOfTurn.to_string(),
+                        TurnEventEntry::StartOfNextTurn,
+                        TurnEventEntry::StartOfNextTurn.to_string(),
                     );
                 });
             ui.label("of");

--- a/tests/conditions_tests.rs
+++ b/tests/conditions_tests.rs
@@ -8,7 +8,7 @@ fn add_condition_adds() {
     let condition = Condition::builder()
         .condition(ValuedCondition::Frightened)
         .value(3)
-        .term(ValuedTerm::Reduced(TurnEvent::EndOfTurn(String::from("bob")), 1))
+        .term(ValuedTerm::Reduced(TurnEvent::EndOfNextTurn(String::from("bob")), 1))
         .build();
 
     cm.add_condition("bob", condition.clone());
@@ -22,7 +22,7 @@ fn remove_condition_removes() {
     let condition = Condition::Valued {
         cond: ValuedCondition::Frightened,
         level: 5,
-        term: ValuedTerm::Reduced(TurnEvent::EndOfTurn(String::from("bob")), 1)
+        term: ValuedTerm::Reduced(TurnEvent::EndOfNextTurn(String::from("bob")), 1)
     };
 
     cm.add_condition("bob", condition.clone());
@@ -45,7 +45,7 @@ fn remove_bleed_doesnt_remove_frighten() {
     let frightened = Condition::Valued {
         cond: ValuedCondition::Frightened,
         level: 3,
-        term: ValuedTerm::Reduced(TurnEvent::EndOfTurn(String::from("bob")), 1)
+        term: ValuedTerm::Reduced(TurnEvent::EndOfNextTurn(String::from("bob")), 1)
     };
 
     cm.add_condition("bob", frightened.clone());
@@ -205,7 +205,7 @@ fn persistent_bleed_10_reduced_start_alice_on_bob() -> tracker::Result<()> {
     let bleed = Condition::builder()
         .condition(ValuedCondition::PersistentDamage(DamageType::Bleed))
         .value(10)
-        .term(ValuedTerm::Reduced(TurnEvent::StartOfTurn(String::from("Alice")), 3))
+        .term(ValuedTerm::Reduced(TurnEvent::StartOfNextTurn(String::from("Alice")), 3))
         .build();
     t.add_condition("Bob", bleed)?;
 


### PR DESCRIPTION
Changed behaviour such that a condition that is added on X's turn with the `until end of X's turn` termination ends not when the current turn ends but upon the
*next* turn ending.

Additionally, changed `start of turn` and `end of turn` to `start of next turn` and `end of next turn` to better reflect this behaviour and match pf2e rule wording.

Related to #8.